### PR TITLE
Revert "change env variable from HOPSWORKS_CERT_DIR to SECRETS_DIR"

### DIFF
--- a/rust/src/hdfs/connection.rs
+++ b/rust/src/hdfs/connection.rs
@@ -38,7 +38,7 @@ use crate::security::sasl::{SaslReader, SaslRpcClient, SaslWriter};
 use crate::security::user::UserInfo;
 use crate::{HdfsError, Result};
 
-const SECRETS_DIR: &str = "SECRETS_DIR";
+const HOPSWORKS_CERT_DIR: &str = "HOPSWORKS_CERT_DIR";
 
 const PROTOCOL: &str = "org.apache.hadoop.hdfs.protocol.ClientProtocol";
 const DATA_TRANSFER_VERSION: u16 = 28;
@@ -77,8 +77,8 @@ async fn connect_tls(addr: &str) -> Result<TlsStream<TcpStream>> {
         cert_chain, 
         key_der) = 
         
-        if !env::var(SECRETS_DIR).is_err() {
-            let pems_dir = env::var(SECRETS_DIR).unwrap();
+        if !env::var(HOPSWORKS_CERT_DIR).is_err() {
+            let pems_dir = env::var(HOPSWORKS_CERT_DIR).unwrap();
 
             let root_ca_bundle_filename: String = format!("ca_chain.pem");
             let client_certificates_bundle_filename: String = format!("client_cert.pem");


### PR DESCRIPTION
This reverts commit 56dac92e67a8841ad3a8e86c2088b8d923c9be65.